### PR TITLE
[TSK-76]モデルにunique制限を追加

### DIFF
--- a/app/Models/Composer.php
+++ b/app/Models/Composer.php
@@ -8,7 +8,7 @@ class Composer extends Model
 {
     protected $table = 'composers';
 
-    protected $fillable = ['name', 'furigana'];
+    protected $guarded = ['id'];
 
     public function musics()
     {

--- a/app/Models/Music.php
+++ b/app/Models/Music.php
@@ -8,7 +8,7 @@ class Music extends Model
 {
     protected $table = 'musics';
     
-    protected $fillable = ['title', 'description', 'composer_id'];
+    protected $guarded = ['id'];
 
     public function composer()
     {

--- a/database/migrations/2024_03_28_140511_add_unique_constraint_to_musics_table.php
+++ b/database/migrations/2024_03_28_140511_add_unique_constraint_to_musics_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('musics', function (Blueprint $table) {
+            $table->unique('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('musics', function (Blueprint $table) {
+            $table->dropUnique('title');
+        });
+    }
+};

--- a/database/migrations/2024_03_28_140726_add_unique_constraint_to_composers_table.php
+++ b/database/migrations/2024_03_28_140726_add_unique_constraint_to_composers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('composers', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('composers', function (Blueprint $table) {
+            $table->dropUnique('name');
+        });
+    }
+};

--- a/database/seeders/MusicSeeder.php
+++ b/database/seeders/MusicSeeder.php
@@ -32,11 +32,6 @@ class MusicSeeder extends Seeder
                 'composer_id' => 2,
             ],
             [
-                'title' => '三つのジャポニスム',
-                'description' => '',
-                'composer_id' => 1,
-            ],
-            [
                 'title' => '大いなる約束の大地〜チンギス・ハーン',
                 'description' => '',
                 'composer_id' => 3,


### PR DESCRIPTION
## 概要 <!-- PRの目的と変更内容の簡単な説明 -->
- マイグレーション作成時にunique制限をつけていなかったため、追加する

## 変更内容 <!-- 変更点の詳細 -->
- Composers、Musicsテーブルにそれぞれunique制限を付与した。その際、既存データに重複データがあったため、一度dropして再度シーダーを実行した。

## 影響範囲 <!-- 変更による影響を受ける機能やモジュール、考慮すべき既知の問題や制限事項 -->
- 

## その他 <!-- 追加の情報や注意点 -->
- 
